### PR TITLE
Support Source Maps like grunt-autoprefixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ grunt.initConfig({
     main: {
       expand: true,
       cwd: 'src/css/',
-      src: '*.css'
+      src: '*.css',
+      dest: 'dest/css/'
     }
   },
 });
@@ -46,6 +47,24 @@ grunt.initConfig({
 ### Options
 
 The options are the same as second argument of [PostCSS](https://github.com/ai/postcss)'s `process()`. With this options, you can update a existing Source Map file. For more information, please read the PostCSS document.
+
+#### options.map
+
+You can set `options.map` same as PostCSS's `process()` (e.g. `true`, `false` and Source Map content). Additionally, you can update an existent Source Map file by specifing its path.
+
+```js
+grunt.initConfig({
+  css_mqpacker: {
+    options: {
+      map: 'src/css/style.css.map'
+    },
+    main: {
+      src: 'src/css/style.css',
+      dest: 'dest/css/style.css'
+    }
+  },
+});
+```
 
 
 ## Contributing

--- a/tasks/css_mqpacker.js
+++ b/tasks/css_mqpacker.js
@@ -22,9 +22,25 @@ module.exports = function (grunt) {
         return next();
       }
 
-      var css = grunt.file.read(src);
-      grunt.file.write(dest, mqpacker.pack(css, options).css);
+      if (options.map) {
+        options.from = src;
+        options.to = dest;
+
+        if (typeof options.map === 'string' && grunt.file.exists(options.map)) {
+          options.map = grunt.file.read(options.map);
+        }
+      }
+
+      var processed = mqpacker.pack(grunt.file.read(src), options);
+      grunt.file.write(dest, processed.css);
       grunt.log.writeln('File ' + dest + ' created.');
+
+      if (options.map) {
+        var map = options.to + '.map';
+        grunt.file.write(map, processed.map);
+        grunt.log.writeln('File ' + map + ' created.');
+      }
+
       next();
     }, function (err) {
       done(err);

--- a/test/expected/custom_options.css
+++ b/test/expected/custom_options.css
@@ -17,4 +17,4 @@
   }
 }
 
-/*# sourceMappingURL=to.css.map */
+/*# sourceMappingURL=custom_options.css.map */


### PR DESCRIPTION
https://github.com/nDmitry/grunt-autoprefixer#optionsmap

``` javascript
css_mqpacker: {
  main: {
    options: {
      // `dest/css/output.css.map`
      map: true
    },
    src: 'src/css/input.css',
    dest: 'dest/css/output.css'
  }
}
```
